### PR TITLE
Get rid of global requirements.txt

### DIFF
--- a/.github/workflows/pytest_with_bazel.yaml
+++ b/.github/workflows/pytest_with_bazel.yaml
@@ -62,7 +62,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          pip install -r research/delta_crit/requirements.txt
+          cd research/delta_crit
+          pip install -r requirements.txt
+          cd ../..
       - name: Do perceptest-specific preparations
         run: |
           cp .env_bazel_test_default .env

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # This file only consists common requirements for code style, testing etc.
 
 # The actual requirements for running the individual `research/` activities are in 
-# separate requirements.txt files. In general they conflict with each other, 
+# their respective requirements.txt files. In general they conflict with each other, 
 # so a developer environment for a given research activity needs to be set up
 # manually by installing both this file and the respetive requirements.txt file.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-# All Python dependencies for running the `research/` activities that are still
-# maintained and that can be installed together into one up-to-date python environment.
--r base/requirements.txt
--r research/delta_crit/requirements.txt
-
-# Research activities that have conflicting outdated dependencies, and therefore
-# need their own separate Python environment (commented out)
-# -r research/v2x_eval/requirements.txt

--- a/research/delta_crit/requirements.txt
+++ b/research/delta_crit/requirements.txt
@@ -1,7 +1,5 @@
-# This file needs to be called from the root of the perceptest repo such that the paths work.
-
 # Own direct requirements
--e ./third_party/commonroad-crime
+-e ../../third_party/commonroad-crime
 notebook
 
 # Indirect requirements from other parts of this codebase


### PR DESCRIPTION
only use individual requirements.txt files for each research activity individually