### PR TITLE
Cleanly modify dynamic obstacles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
         "PYTHONPATH": "${workspaceFolder}:${env:PYTHONPATH}"
       },
       "console": "integratedTerminal",
-      "justMyCode": true
+      "justMyCode": false
     },
   ]
 }

--- a/research/delta_crit/conftest.py
+++ b/research/delta_crit/conftest.py
@@ -3,7 +3,7 @@ from commonroad.scenario.scenario import Scenario  # type: ignore
 from commonroad_crime.data_structure.configuration import CriMeConfiguration  # type: ignore
 
 from research.delta_crit.crime_utils.crime_utils import get_scenario, get_scenario_config
-from research.delta_crit.scenario.simplify_scenario import simplify_scenario
+from research.delta_crit.scenario.simplify_scenario import strip_down_to_test_scenario
 
 
 @pytest.fixture
@@ -23,13 +23,13 @@ def example_config_garching(scenario_id_garching: str) -> CriMeConfiguration:
 
 @pytest.fixture
 def scenario_simplified_straight(example_scenario_garching: Scenario) -> Scenario:
-    scenario = simplify_scenario(example_scenario_garching, ego_id=200)
+    scenario = strip_down_to_test_scenario(example_scenario_garching, ego_id=200)
     return scenario
 
 
 @pytest.fixture
 def scenario_simplified_side(example_scenario_garching: Scenario) -> Scenario:
-    scenario = simplify_scenario(example_scenario_garching, ego_id=200, targets_east=0, targets_north=10)
+    scenario = strip_down_to_test_scenario(example_scenario_garching, ego_id=200, targets_east=0, targets_north=10)
     return scenario
 
 

--- a/research/delta_crit/pem/conftest.py
+++ b/research/delta_crit/pem/conftest.py
@@ -45,3 +45,16 @@ def temporal_pem_config_path() -> str:
 @pytest.fixture
 def temporal_pem_config(temporal_pem_config_path: str) -> PemConfig:
     return pem_config_from_json(temporal_pem_config_path)
+
+
+@pytest.fixture
+def all_objects_pem_config_path() -> str:
+    PERCEPTEST_ROOT = os.environ.get("PERCEPTEST_REPO")
+    assert PERCEPTEST_ROOT
+    file_path: str = os.path.join(PERCEPTEST_ROOT, "research/delta_crit/pem/example_configs/all_objects.json")
+    return file_path
+
+
+@pytest.fixture
+def all_objects_pem_config(all_objects_pem_config_path: str) -> PemConfig:
+    return pem_config_from_json(all_objects_pem_config_path)

--- a/research/delta_crit/pem/create_sut_scenario.py
+++ b/research/delta_crit/pem/create_sut_scenario.py
@@ -14,7 +14,7 @@ from research.delta_crit.crime_utils.crime_utils import (
     write_scenario_config,
 )
 from research.delta_crit.pem.pem_config import PemConfig, Perror, pem_config_from_json
-from research.delta_crit.scenario.utils import refresh_dynamic_obstacles
+from research.delta_crit.scenario.refresh_dynamic_obstacles import refresh_dynamic_obstacles
 
 
 def create_sut_scenario_files(

--- a/research/delta_crit/pem/create_sut_scenario.py
+++ b/research/delta_crit/pem/create_sut_scenario.py
@@ -58,13 +58,14 @@ def apply_perror_to_scenario(scenario: Scenario, perror: Perror, ego_vehicle: Dy
 
 
 def obtain_time_range_to_modify(perror: Perror, obstacle: DynamicObstacle) -> list[int]:
-    start_timestep: int = max(perror.start_timestep, obstacle.prediction.trajectory.initial_time_step)
+    start_timestep: int = max(perror.start_timestep, obstacle.initial_state.time_step)
 
-    end_timestep: int = min(perror.end_timestep, obstacle.prediction.trajectory.final_state.time_step)
     if perror.end_timestep == -1:
-        end_timestep = obstacle.prediction.trajectory.final_state.time_step
+        end_timestep = obstacle.prediction.final_time_step
+    else:
+        end_timestep = min(perror.end_timestep, obstacle.prediction.final_time_step)
 
-    return list(range(start_timestep, end_timestep))
+    return list(range(start_timestep, end_timestep + 1))
 
 
 def obtain_obstacles_to_modify(

--- a/research/delta_crit/pem/create_sut_scenario.py
+++ b/research/delta_crit/pem/create_sut_scenario.py
@@ -35,27 +35,47 @@ def create_sut_scenario(crime_config: CriMeConfiguration, pem_config: PemConfig)
     ego_vehicle: DynamicObstacle = sut_scenario.obstacle_by_id(crime_config.vehicle.ego_id)
 
     for perror in pem_config:
-        if perror.object_id == -1:
-            obstacles_to_modify = []
-            for dynamic_obstacle in sut_scenario.dynamic_obstacles:
-                if dynamic_obstacle.obstacle_id != ego_vehicle.obstacle_id:
-                    obstacles_to_modify.append(dynamic_obstacle)
-        else:
-            obstacles_to_modify = [sut_scenario.obstacle_by_id(perror.object_id)]
+        apply_perror_to_scenario(scenario=sut_scenario, perror=perror, ego_vehicle=ego_vehicle)
 
-        for obstacle in obstacles_to_modify:
-            start_timestep = max(perror.start_timestep, obstacle.prediction.trajectory.initial_time_step)
-
-            end_timestep = min(perror.end_timestep, obstacle.prediction.trajectory.final_state.time_step)
-            if perror.end_timestep == -1:
-                end_timestep = obstacle.prediction.trajectory.final_state.time_step
-
-            for timestep in range(start_timestep, end_timestep):
-                ego_state: TraceState = ego_vehicle.state_at_time(time_step=timestep)
-                obstacle_state: TraceState = obstacle.state_at_time(time_step=timestep)
-                add_offset_long_lat(ego_state=ego_state, obstacle_state=obstacle_state, perror=perror)
-                add_offset_range_azimuth(ego_state, obstacle_state=obstacle_state, perror=perror)
     return sut_scenario, sut_config
+
+
+def apply_perror_to_scenario(scenario: Scenario, perror: Perror, ego_vehicle: DynamicObstacle) -> None:
+    obstacles_to_modify: list[DynamicObstacle] = obtain_obstacles_to_modify(
+        scenario=scenario, perror=perror, ego_vehicle=ego_vehicle
+    )
+    for obstacle in obstacles_to_modify:
+        time_range_to_modify: list[int] = obtain_time_range_to_modify(perror=perror, obstacle=obstacle)
+
+        for timestep in time_range_to_modify:
+            ego_state: TraceState = ego_vehicle.state_at_time(time_step=timestep)
+            obstacle_state: TraceState = obstacle.state_at_time(time_step=timestep)
+
+            add_offset_long_lat(ego_state=ego_state, obstacle_state=obstacle_state, perror=perror)
+            add_offset_range_azimuth(ego_state, obstacle_state=obstacle_state, perror=perror)
+
+
+def obtain_time_range_to_modify(perror: Perror, obstacle: DynamicObstacle) -> list[int]:
+    start_timestep: int = max(perror.start_timestep, obstacle.prediction.trajectory.initial_time_step)
+
+    end_timestep: int = min(perror.end_timestep, obstacle.prediction.trajectory.final_state.time_step)
+    if perror.end_timestep == -1:
+        end_timestep = obstacle.prediction.trajectory.final_state.time_step
+
+    return list(range(start_timestep, end_timestep))
+
+
+def obtain_obstacles_to_modify(
+    scenario: Scenario, perror: Perror, ego_vehicle: DynamicObstacle
+) -> list[DynamicObstacle]:
+    if perror.object_id == -1:
+        obstacles_to_modify = []
+        for dynamic_obstacle in scenario.dynamic_obstacles:
+            if dynamic_obstacle.obstacle_id != ego_vehicle.obstacle_id:
+                obstacles_to_modify.append(dynamic_obstacle)
+    else:
+        obstacles_to_modify = [scenario.obstacle_by_id(perror.object_id)]
+    return obstacles_to_modify
 
 
 def add_offset_long_lat(ego_state: TraceState, obstacle_state: TraceState, perror: Perror) -> None:

--- a/research/delta_crit/pem/create_sut_scenario.py
+++ b/research/delta_crit/pem/create_sut_scenario.py
@@ -14,6 +14,7 @@ from research.delta_crit.crime_utils.crime_utils import (
     write_scenario_config,
 )
 from research.delta_crit.pem.pem_config import PemConfig, Perror, pem_config_from_json
+from research.delta_crit.scenario.utils import refresh_dynamic_obstacles
 
 
 def create_sut_scenario_files(
@@ -37,6 +38,7 @@ def create_sut_scenario(crime_config: CriMeConfiguration, pem_config: PemConfig)
     for perror in pem_config:
         apply_perror_to_scenario(scenario=sut_scenario, perror=perror, ego_vehicle=ego_vehicle)
 
+    refresh_dynamic_obstacles(scenario=sut_scenario)
     return sut_scenario, sut_config
 
 

--- a/research/delta_crit/pem/create_sut_scenario_test.py
+++ b/research/delta_crit/pem/create_sut_scenario_test.py
@@ -5,9 +5,6 @@ from math import isclose
 
 import commonroad_crime.utility.visualization as utils_vis
 import pytest
-from commonroad.geometry.shape import Rectangle  # type: ignore
-from commonroad.prediction.prediction import Occupancy  # type: ignore
-from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
 from commonroad.scenario.state import ExtendedPMState, InitialState  # type: ignore
 
 from research.delta_crit.crime_utils.crime_utils import (
@@ -15,6 +12,10 @@ from research.delta_crit.crime_utils.crime_utils import (
 )
 from research.delta_crit.pem.create_sut_scenario import create_sut_scenario, create_sut_scenario_files
 from research.delta_crit.pem.pem_config import PemConfig
+from research.delta_crit.scenario.assertion_utils import (
+    assert_constant_obstacle,
+    assert_obstacles_present,
+)
 
 
 def test_create_sut_scenario_apply_to_all_objects(
@@ -29,36 +30,23 @@ def test_create_sut_scenario_apply_to_all_objects(
         plot_limit=crime_config.debug.plot_limits,
         time_steps=[0],
         print_obstacle_ids=True,
+        print_lanelet_ids=True,
     )
 
     # Assertions
     ego_id = 200
-    abs_tol: float = 1e-11
-    for timestep in range(0, 22):
-        for obs_id in [200, 201, 202, 203]:
-            if timestep == 21:
-                assert sut_scenario.obstacle_by_id(obs_id).state_at_time(timestep) is None
-                continue
-
-            expected_east: float = 0 if obs_id == ego_id else -20
-            expected_north: float = 0
-            expected_orientation: float = 0
-
-            obstacle: DynamicObstacle = sut_scenario.obstacle_by_id(obs_id)
-
-            obstacle_state = obstacle.state_at_time(timestep)
-            assert isinstance(obstacle_state, InitialState if timestep == 0 else ExtendedPMState)
-
-            assert isclose(obstacle_state.position[0], expected_east, abs_tol=abs_tol)
-            assert isclose(obstacle_state.position[1], expected_north, abs_tol=abs_tol)
-            assert isclose(obstacle_state.orientation, expected_orientation, abs_tol=abs_tol)
-
-            obstacle_occupancy: Occupancy = obstacle.occupancy_at_time(timestep)
-            assert isinstance(obstacle_occupancy.shape, Rectangle)
-            assert obstacle_occupancy.shape.center[0] == expected_east
-            assert obstacle_occupancy.shape.center[1] == expected_north
-            assert obstacle_occupancy.shape.orientation == expected_orientation
-    pass
+    assert_obstacles_present(scenario=sut_scenario, expected_obstacle_ids=[200, 201, 202, 203])
+    for obstacle in sut_scenario.dynamic_obstacles:
+        assert_constant_obstacle(
+            obstacle=obstacle,
+            expected_east=0 if obstacle.obstacle_id == ego_id else -20,
+            expected_north=0,
+            expected_orientation=0,
+            expected_initial_state_stamp=0,
+            expected_final_time_stamp=20,
+            expected_lanelet_ids=set([47240]),
+            lanelet_network=sut_scenario.lanelet_network,
+        )
 
 
 def test_create_sut_scenario_multiple_timesteps(

--- a/research/delta_crit/pem/create_sut_scenario_test.py
+++ b/research/delta_crit/pem/create_sut_scenario_test.py
@@ -23,6 +23,14 @@ def test_create_sut_scenario_apply_to_all_objects(
     crime_config = config_simplified_straight
     sut_scenario, sut_config = create_sut_scenario(crime_config=crime_config, pem_config=all_objects_pem_config)
 
+    # Visual Insights
+    utils_vis.visualize_scenario_at_time_steps(
+        sut_scenario,
+        plot_limit=crime_config.debug.plot_limits,
+        time_steps=[0],
+        print_obstacle_ids=True,
+    )
+
     # Assertions
     ego_id = 200
     abs_tol: float = 1e-11
@@ -50,14 +58,6 @@ def test_create_sut_scenario_apply_to_all_objects(
             assert obstacle_occupancy.shape.center[0] == expected_east
             assert obstacle_occupancy.shape.center[1] == expected_north
             assert obstacle_occupancy.shape.orientation == expected_orientation
-
-    # Visual Insights
-    utils_vis.visualize_scenario_at_time_steps(
-        sut_scenario,
-        plot_limit=crime_config.debug.plot_limits,
-        time_steps=[0, 1, 2, 3, 18, 19, 20],
-        print_obstacle_ids=True,
-    )
     pass
 
 

--- a/research/delta_crit/pem/example_configs/all_objects.json
+++ b/research/delta_crit/pem/example_configs/all_objects.json
@@ -1,0 +1,20 @@
+[
+  {
+    "start_timestep": 0,
+    "end_timestep": -1,
+    "offset_longitudinal": 0,
+    "offset_lateral": 0,
+    "offset_range": 10,
+    "offset_azimuth": 0,
+    "object_id": -1
+  },
+  {
+    "start_timestep": 0,
+    "end_timestep": -1,
+    "offset_longitudinal": 0,
+    "offset_lateral": 0,
+    "offset_range": 0,
+    "offset_azimuth": 180,
+    "object_id": -1
+  }
+]

--- a/research/delta_crit/scenario/assertion_utils.py
+++ b/research/delta_crit/scenario/assertion_utils.py
@@ -1,0 +1,117 @@
+from math import isclose
+
+from commonroad.geometry.shape import Rectangle  # type: ignore
+from commonroad.prediction.prediction import TrajectoryPrediction  # type: ignore
+from commonroad.scenario.lanelet import LaneletNetwork  # type: ignore
+from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
+from commonroad.scenario.scenario import Scenario  # type: ignore
+from commonroad.scenario.state import ExtendedPMState  # type: ignore
+
+
+def assert_obstacles_present(scenario: Scenario, expected_obstacle_ids: list[int], allow_subset: bool = False) -> None:
+    seen_obstacle_ids = []
+    for obstacle in scenario.dynamic_obstacles:
+        seen_obstacle_ids.append(obstacle.obstacle_id)
+
+    if not allow_subset:
+        assert sorted(seen_obstacle_ids) == sorted(expected_obstacle_ids)
+    else:
+        assert set(seen_obstacle_ids) in set(expected_obstacle_ids)
+
+
+def assert_constant_obstacle_properties(
+    obstacle: DynamicObstacle,
+    expected_east: float,
+    expected_north: float,
+    expected_orientation: float,
+    expected_initial_state_stamp: int,
+    expected_final_time_stamp: int,
+    abs_tol: float = 1e-11,
+) -> None:
+    # Check initial state
+    assert isclose(obstacle.initial_state.position[0], expected_east, abs_tol=abs_tol)
+    assert isclose(obstacle.initial_state.position[1], expected_north, abs_tol=abs_tol)
+    assert isclose(obstacle.initial_state.orientation, expected_orientation, abs_tol=abs_tol)
+
+    obs_prediction: TrajectoryPrediction = obstacle.prediction
+
+    # Check states of trajectory prediction
+    seen_trajectory_state_timestamps = []
+    for state in obs_prediction.trajectory.state_list:
+        seen_trajectory_state_timestamps.append(state.time_step)
+        assert isinstance(state, ExtendedPMState)
+        assert isclose(state.position[0], expected_east, abs_tol=abs_tol)
+        assert isclose(state.position[1], expected_north, abs_tol=abs_tol)
+        assert isclose(state.orientation, expected_orientation, abs_tol=abs_tol)
+
+    # Check occupancies of trajectory prediction
+    seen_occupancy_timestamps = []
+    for occupancy in obs_prediction.occupancy_set:
+        seen_occupancy_timestamps.append(occupancy.time_step)
+        assert isinstance(occupancy.shape, Rectangle)
+        assert occupancy.shape.center[0] == expected_east
+        assert occupancy.shape.center[1] == expected_north
+        assert occupancy.shape.orientation == expected_orientation
+
+    # Check timing consistency
+    assert obstacle.initial_state.time_step == expected_initial_state_stamp
+    assert obs_prediction.initial_time_step == expected_initial_state_stamp + 1
+    expected_trajectory_time_stamps = list(range(expected_initial_state_stamp + 1, expected_final_time_stamp + 1))
+    assert sorted(seen_trajectory_state_timestamps) == expected_trajectory_time_stamps
+    assert sorted(seen_occupancy_timestamps) == expected_trajectory_time_stamps
+
+
+def assert_constant_lanelet_refs_in_obstacle(obstacle: DynamicObstacle, expected_lanelet_ids: set) -> None:
+    """Assumes shape lanelets and center lanelets are the same and constant over time."""
+
+    obs_prediction: TrajectoryPrediction = obstacle.prediction
+
+    # Check lanelet references in obstacle (initial state)
+    assert obstacle.initial_shape_lanelet_ids == expected_lanelet_ids
+    assert obstacle.initial_center_lanelet_ids == expected_lanelet_ids
+
+    # Check lanelet references in obstacle prediction
+    expected_prediction_lanelet_assignment = {
+        i: expected_lanelet_ids for i in range(obs_prediction.initial_time_step, obs_prediction.final_time_step + 1)
+    }
+    assert obs_prediction.shape_lanelet_assignment == expected_prediction_lanelet_assignment
+    assert obs_prediction.center_lanelet_assignment == expected_prediction_lanelet_assignment
+
+
+def assert_obstacle_referenced_by_lanelet_network(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> None:
+    obs_prediction: TrajectoryPrediction = obstacle.prediction
+
+    for time_step, lanelet_ids in obs_prediction.shape_lanelet_assignment.items():
+        for lanelet_id in lanelet_ids:
+            lanelet_dict = lanelet_network.find_lanelet_by_id(lanelet_id).dynamic_obstacles_on_lanelet
+            assert obstacle.obstacle_id in lanelet_dict[time_step]
+
+    for time_step, lanelet_ids in obs_prediction.center_lanelet_assignment.items():
+        for lanelet_id in lanelet_ids:
+            lanelet_dict = lanelet_network.find_lanelet_by_id(lanelet_id).dynamic_obstacles_on_lanelet
+            assert obstacle.obstacle_id in lanelet_dict[time_step]
+
+
+def assert_constant_obstacle(
+    obstacle: DynamicObstacle,
+    expected_east: float,
+    expected_north: float,
+    expected_orientation: float,
+    expected_initial_state_stamp: int,
+    expected_final_time_stamp: int,
+    expected_lanelet_ids: set,
+    lanelet_network: LaneletNetwork,
+    abs_tol: float = 1e-11,
+) -> None:
+    assert_constant_obstacle_properties(
+        obstacle=obstacle,
+        expected_east=expected_east,
+        expected_north=expected_north,
+        expected_orientation=expected_orientation,
+        expected_initial_state_stamp=expected_initial_state_stamp,
+        expected_final_time_stamp=expected_final_time_stamp,
+        abs_tol=abs_tol,
+    )
+
+    assert_constant_lanelet_refs_in_obstacle(obstacle=obstacle, expected_lanelet_ids=expected_lanelet_ids)
+    assert_obstacle_referenced_by_lanelet_network(obstacle=obstacle, lanelet_network=lanelet_network)

--- a/research/delta_crit/scenario/assertion_utils.py
+++ b/research/delta_crit/scenario/assertion_utils.py
@@ -1,7 +1,7 @@
 from math import isclose
 
 from commonroad.geometry.shape import Rectangle  # type: ignore
-from commonroad.prediction.prediction import TrajectoryPrediction  # type: ignore
+from commonroad.prediction.prediction import Occupancy, TrajectoryPrediction  # type: ignore
 from commonroad.scenario.lanelet import LaneletNetwork  # type: ignore
 from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
 from commonroad.scenario.scenario import Scenario  # type: ignore
@@ -32,6 +32,13 @@ def assert_constant_obstacle_properties(
     assert isclose(obstacle.initial_state.position[0], expected_east, abs_tol=abs_tol)
     assert isclose(obstacle.initial_state.position[1], expected_north, abs_tol=abs_tol)
     assert isclose(obstacle.initial_state.orientation, expected_orientation, abs_tol=abs_tol)
+
+    # Check initial occupancy
+    initial_occupancy: Occupancy = obstacle.occupancy_at_time(obstacle.initial_state.time_step)
+    assert isinstance(initial_occupancy.shape, Rectangle)
+    assert initial_occupancy.shape.center[0] == expected_east
+    assert initial_occupancy.shape.center[1] == expected_north
+    assert initial_occupancy.shape.orientation == expected_orientation
 
     obs_prediction: TrajectoryPrediction = obstacle.prediction
 

--- a/research/delta_crit/scenario/refresh_dynamic_obstacles.py
+++ b/research/delta_crit/scenario/refresh_dynamic_obstacles.py
@@ -1,6 +1,3 @@
-from copy import deepcopy
-
-from commonroad.common.reader.file_reader_xml import DynamicObstacleFactory  #  type: ignore
 from commonroad.prediction.prediction import TrajectoryPrediction  # type: ignore
 from commonroad.scenario.lanelet import LaneletNetwork  # type: ignore
 from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
@@ -9,26 +6,28 @@ from commonroad.scenario.state import InitialState  # type: ignore
 
 
 def refresh_dynamic_obstacles(scenario: Scenario) -> Scenario:
-    """Call this function after modifying obstacles' positions, orientations, and/or shape.
-    It makes sure the scenario properties stay consistent. Especially:
-    - assignments lanelet <-> obstacle
-    - occupancy
+    """
+    Recomputes:
+    - assignments lanelets <-> obstacle
+    - occupancies
+    based on positions, orientations, and shape.
 
     See also https://github.com/CommonRoad/commonroad-io/issues/12
     """
 
     assert_predictions_are_trajectories(scenario=scenario)
+
+    # Might not be needed here, but makes it safer
     clear_dynamic_obstacles_from_lanelets(lanelet_network=scenario.lanelet_network)
 
     for old_obstacle in scenario.dynamic_obstacles:
-        exchange_by_fresh_obstacle(scenario=scenario, obstacle=old_obstacle)
+        refresh_dynamic_obstacle(scenario=scenario, obstacle=old_obstacle)
     return scenario
 
 
 def assert_predictions_are_trajectories(scenario: Scenario) -> None:
     for obstacle in scenario.dynamic_obstacles:
-        if not isinstance(obstacle.prediction, TrajectoryPrediction):
-            raise ValueError("Can only refresh TrajectoryPrediction")
+        assert isinstance(obstacle.prediction, TrajectoryPrediction)
 
 
 def clear_dynamic_obstacles_from_lanelets(lanelet_network: LaneletNetwork) -> LaneletNetwork:
@@ -37,13 +36,20 @@ def clear_dynamic_obstacles_from_lanelets(lanelet_network: LaneletNetwork) -> La
     return lanelet_network
 
 
-def exchange_by_fresh_obstacle(scenario: Scenario, obstacle: DynamicObstacle) -> Scenario:
-    new_obstacle = deepcopy(obstacle)
-    scenario.remove_obstacle(obstacle)  # This also removes the obstacle from its old lanelets
+def refresh_dynamic_obstacle(scenario: Scenario, obstacle: DynamicObstacle) -> Scenario:
+    """Remove obstacle by ID from scenario deeply; then re-add obstacle deeply."""
 
-    recompute_lanelet_assignments(obstacle=new_obstacle, lanelet_network=scenario.lanelet_network)
-    scenario.add_objects(new_obstacle)  # This also adds the obstacle to its new lanelets
-    recompute_occupancy_set(new_obstacle.prediction)
+    # This also removes the obstacle from its old lanelets.
+    # We can continue using the obstacle here after it is no longer part of the scenario.
+    scenario.remove_obstacle(obstacle)
+
+    add_obstacle_deeply(scenario=scenario, obstacle=obstacle)
+
+
+def add_obstacle_deeply(scenario: Scenario, obstacle: DynamicObstacle) -> Scenario:
+    recompute_lanelet_assignments(obstacle=obstacle, lanelet_network=scenario.lanelet_network)
+    scenario.add_objects(obstacle)  # This also adds the obstacle to its new lanelets
+    recompute_occupancy_set(obstacle.prediction)
 
 
 def recompute_occupancy_set(prediction: TrajectoryPrediction) -> TrajectoryPrediction:
@@ -54,70 +60,122 @@ def recompute_occupancy_set(prediction: TrajectoryPrediction) -> TrajectoryPredi
 
 def recompute_lanelet_assignments(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
     """
-    Based on modified
-    - obstacle.prediction.trajectory
-    - obstacle.initial_state,
-    recompute which lanelets their shapes and centers are on.
+    Recompute references in both directions (obstacle <-> lanelet_network).
 
-    See also https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/common/reader/file_reader_xml.py#L1254"""
+    Both for prediction.trajectory and initial_state.
 
-    recompute_initial_lanelet_assignment(obstacle=obstacle, lanelet_network=lanelet_network)
+    Inspiration:
+    - https://github.com/CommonRoad/commonroad-io/issues/12#issuecomment-2593494787
+    - https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/common/reader/file_reader_xml.py#L1254
+    """
+
+    recompute_initial_state_lanelet_assignment(obstacle=obstacle, lanelet_network=lanelet_network)
     recompute_prediction_lanelet_assignment(obstacle=obstacle, lanelet_network=lanelet_network)
     return obstacle
 
 
-def recompute_initial_lanelet_assignment(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
-    # We first need to recompute lanelet ids in the initial state,
-    # and only then add the initial state to the lanelet network.
+def recompute_initial_state_lanelet_assignment(
+    obstacle: DynamicObstacle, lanelet_network: LaneletNetwork
+) -> DynamicObstacle:
+    """Based on `initial_state` and `obstacle_shape`, recompute `initial_{shape|center}_lanelet_ids`.
+    Then, add the initial state to the lanelet network."""
+
+    # Direction obstacle -> lanelets (needs to go first)
     recompute_lanelet_ids_in_initial_state(obstacle=obstacle, lanelet_network=lanelet_network)
+
+    # Direction lanelets -> obstacle (needs to go last)
     add_initial_state_to_lanelet_network(obstacle=obstacle, lanelet_network=lanelet_network)
+    return obstacle
+
+
+def recompute_prediction_lanelet_assignment(
+    obstacle: DynamicObstacle, lanelet_network: LaneletNetwork
+) -> DynamicObstacle:
+    """Based on `obstacle.prediction`, recompute `obstacle.prediction.{shape|center}_lanelet_assignment`.
+    Then, add the prediction to the lanelet network."""
+
+    # Direction obstacle -> lanelets (needs to go first)
+    recompute_shape_lanelet_assignment(obstacle=obstacle, lanelet_network=lanelet_network)
+    recompute_center_lanelet_assignment(obstacle=obstacle, lanelet_network=lanelet_network)
+
+    # Direction lanelets -> obstacle (needs to go last)
+    add_prediction_to_lanelet_network(obstacle=obstacle, lanelet_network=lanelet_network)
     return obstacle
 
 
 def recompute_lanelet_ids_in_initial_state(
     obstacle: DynamicObstacle, lanelet_network: LaneletNetwork
 ) -> DynamicObstacle:
-    """Based on `initial_state` and `obstacle_shape`, recompute `initial_{shape|center}_lanelet_ids`."""
-
     initial_state: InitialState = obstacle.initial_state
     rotated_shape = obstacle.obstacle_shape.rotate_translate_local(initial_state.position, initial_state.orientation)
     obstacle.initial_shape_lanelet_ids = set(lanelet_network.find_lanelet_by_shape(rotated_shape))
     obstacle.initial_center_lanelet_ids = set(lanelet_network.find_lanelet_by_position([initial_state.position])[0])
 
 
-def add_initial_state_to_lanelet_network(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> LaneletNetwork:
-    for l_id in obstacle.initial_shape_lanelet_ids:
+def add_initial_state_to_lanelet_network(
+    obstacle: DynamicObstacle, lanelet_network: LaneletNetwork, use_shape: bool = True
+) -> LaneletNetwork:
+    """Use shape lanelets by default because the shape covers more lanelets than just the center."""
+
+    lanelet_ids = obstacle.initial_shape_lanelet_ids if use_shape else obstacle.initial_center_lanelet_ids
+    assert lanelet_ids is not None, "Lanelet IDs must be computed first"
+
+    for l_id in lanelet_ids:
         lanelet_network.find_lanelet_by_id(l_id).add_dynamic_obstacle_to_lanelet(
             obstacle_id=obstacle.obstacle_id, time_step=obstacle.initial_state.time_step
         )
     return lanelet_network
 
 
-def recompute_prediction_lanelet_assignment(
-    obstacle: DynamicObstacle, lanelet_network: LaneletNetwork
-) -> DynamicObstacle:
-    """Based on `obstacle.prediction`, recompute `obstacle.prediction.{shape|center}_lanelet_assignment`."""
+def recompute_shape_lanelet_assignment(
+    obstacle: DynamicObstacle,
+    lanelet_network: LaneletNetwork,
+) -> None:
+    """Of an obstacle's prediction"""
 
-    prediction: TrajectoryPrediction = obstacle.prediction  # for better type hinting
+    assert isinstance(obstacle.prediction, TrajectoryPrediction)
+    # Maps the state's time step to a set of lanelets
+    lanelet_ids_per_state: dict[int, set[int]] = {}
 
-    # Note that the following two functions also add the initial_state's lanelets to the
-    # prediction's {shape|center}_lanelet_assignment.
-    # This should be no problem because CommonRoad intends the initial state to be
-    # one time step earlier than the prediction's first state.
-    # See also https://github.com/CommonRoad/commonroad-io/issues/13.
+    for state in obstacle.prediction.trajectory.state_list:
+        rotated_shape = obstacle.obstacle_shape.rotate_translate_local(state.position, state.orientation)
+        lanelet_ids = lanelet_network.find_lanelet_by_shape(rotated_shape)
+        lanelet_ids_per_state[state.time_step] = set(lanelet_ids)
+    obstacle.prediction.shape_lanelet_assignment = lanelet_ids_per_state
 
-    # This also adds the shape lanelets to the lanelet network!
-    prediction.shape_lanelet_assignment = DynamicObstacleFactory.find_obstacle_shape_lanelets(
-        obstacle.initial_state,
-        prediction.trajectory.state_list,
-        lanelet_network,
-        obstacle.obstacle_id,
-        obstacle.obstacle_shape,
-    )
 
-    # This does *not* add the center lanelets to the lanelet network, most likely because they are
-    # a subset of the shape lanelets anyway, which got added above already.
-    prediction.center_lanelet_assignment = DynamicObstacleFactory.find_obstacle_center_lanelets(
-        obstacle.initial_state, prediction.trajectory.state_list, lanelet_network
-    )
-    return obstacle
+def recompute_center_lanelet_assignment(
+    obstacle: DynamicObstacle,
+    lanelet_network: LaneletNetwork,
+) -> None:
+    """Of an obstacle's prediction"""
+
+    assert isinstance(obstacle.prediction, TrajectoryPrediction)
+    # Maps the state's time step to a set of lanelets
+    lanelet_ids_per_state: dict[int, set[int]] = {}
+
+    for state in obstacle.prediction.trajectory.state_list:
+        lanelet_ids = lanelet_network.find_lanelet_by_position([state.position])[0]
+        lanelet_ids_per_state[state.time_step] = set(lanelet_ids)
+
+    obstacle.prediction.center_lanelet_assignment = lanelet_ids_per_state
+
+
+def add_prediction_to_lanelet_network(
+    obstacle: DynamicObstacle, lanelet_network: LaneletNetwork, use_shape: bool = True
+) -> LaneletNetwork:
+    """Use shape lanelets by default because the shape covers more lanelets than just the center."""
+
+    assert isinstance(obstacle.prediction, TrajectoryPrediction)
+    if use_shape:
+        lanelet_assignment = obstacle.prediction.shape_lanelet_assignment
+    else:
+        lanelet_assignment = obstacle.prediction.center_lanelet_assignment
+
+    assert lanelet_assignment is not None, "Lanelet assignment must be computed first"
+    for time_step, lanelet_ids in lanelet_assignment.items():
+        for l_id in lanelet_ids:
+            lanelet_network.find_lanelet_by_id(l_id).add_dynamic_obstacle_to_lanelet(
+                obstacle_id=obstacle.obstacle_id, time_step=time_step
+            )
+    return lanelet_network

--- a/research/delta_crit/scenario/refresh_dynamic_obstacles.py
+++ b/research/delta_crit/scenario/refresh_dynamic_obstacles.py
@@ -1,4 +1,3 @@
-# import numpy as np
 from copy import deepcopy
 
 from commonroad.common.reader.file_reader_xml import DynamicObstacleFactory  #  type: ignore

--- a/research/delta_crit/scenario/simplify_scenario.py
+++ b/research/delta_crit/scenario/simplify_scenario.py
@@ -4,7 +4,9 @@ from research.delta_crit.scenario.create_dynamic_obstacle import create_steady_d
 from research.delta_crit.scenario.refresh_dynamic_obstacles import refresh_dynamic_obstacles
 
 
-def simplify_scenario(scenario: Scenario, ego_id: int, targets_east: float = 10, targets_north: float = 0) -> Scenario:
+def strip_down_to_test_scenario(
+    scenario: Scenario, ego_id: int, targets_east: float = 10, targets_north: float = 0
+) -> Scenario:
     """Create a minimal scenario with ego vehicle at 0,0 and all other dynamic obstacles at targets_east, targets_north. Otherwise, default values."""
 
     target_ids: list[int] = [obs.obstacle_id for obs in scenario.dynamic_obstacles if obs.obstacle_id != ego_id]

--- a/research/delta_crit/scenario/simplify_scenario.py
+++ b/research/delta_crit/scenario/simplify_scenario.py
@@ -1,6 +1,7 @@
 from commonroad.scenario.scenario import Scenario  # type: ignore
 
 from research.delta_crit.scenario.create_dynamic_obstacle import create_steady_dynamic_obstacle
+from research.delta_crit.scenario.refresh_dynamic_obstacles import refresh_dynamic_obstacles
 
 
 def simplify_scenario(scenario: Scenario, ego_id: int, targets_east: float = 10, targets_north: float = 0) -> Scenario:
@@ -19,4 +20,5 @@ def simplify_scenario(scenario: Scenario, ego_id: int, targets_east: float = 10,
         )
         scenario.add_objects(target_vehicle)
 
+    refresh_dynamic_obstacles(scenario=scenario)
     return scenario

--- a/research/delta_crit/scenario/simplify_scenario_test.py
+++ b/research/delta_crit/scenario/simplify_scenario_test.py
@@ -1,10 +1,10 @@
 import sys
 from math import isclose
 
-# import commonroad_crime.utility.visualization as utils_vis  # type: ignore
+import commonroad_crime.utility.visualization as utils_vis  # type: ignore
 import pytest
 from commonroad.geometry.shape import Rectangle  # type: ignore
-from commonroad.prediction.prediction import Occupancy  # type: ignore
+from commonroad.prediction.prediction import Occupancy, TrajectoryPrediction  # type: ignore
 from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
 from commonroad.scenario.scenario import Scenario  # type: ignore
 from commonroad.scenario.state import ExtendedPMState, InitialState  # type: ignore
@@ -13,10 +13,10 @@ from commonroad_crime.data_structure.configuration import CriMeConfiguration  # 
 from research.delta_crit.scenario.simplify_scenario import simplify_scenario
 
 
-def test_simplify_scenario_all_properties_match(config_simplified_straight: CriMeConfiguration) -> None:
+def test_simplify_scenario_all_properties_match(example_config_garching: CriMeConfiguration) -> None:
     # Function under test
     ego_id: int = 200
-    scenario: Scenario = simplify_scenario(scenario=config_simplified_straight.scenario, ego_id=ego_id)
+    scenario: Scenario = simplify_scenario(scenario=example_config_garching.scenario, ego_id=ego_id)
 
     # Assertions
     ego_id = 200
@@ -46,14 +46,84 @@ def test_simplify_scenario_all_properties_match(config_simplified_straight: CriM
             assert obstacle_occupancy.shape.center[1] == expected_north
             assert obstacle_occupancy.shape.orientation == expected_orientation
 
+    # Assertions differently formulated
+    # TODO THIS IS INSANITY
+    # WRITE ASSERTION UTILITIES TO SIMPLIFY IT
+    seen_obstacle_ids = []
+    for obstacle in scenario.dynamic_obstacles:
+        seen_obstacle_ids.append(obstacle.obstacle_id)
+
+        expected_east = 0 if obstacle.obstacle_id == ego_id else 10
+        expected_north = 0
+        expected_orientation = 0
+
+        # Check initial state
+        assert isclose(obstacle.initial_state.position[0], expected_east, abs_tol=abs_tol)
+        assert isclose(obstacle.initial_state.position[1], expected_north, abs_tol=abs_tol)
+        assert isclose(obstacle.initial_state.orientation, expected_orientation, abs_tol=abs_tol)
+
+        obs_prediction: TrajectoryPrediction = obstacle.prediction
+
+        # Check states of trajectory prediction
+        seen_trajectory_state_timestamps = []
+        for state in obs_prediction.trajectory.state_list:
+            seen_trajectory_state_timestamps.append(state.time_step)
+            assert isinstance(state, ExtendedPMState)
+            assert isclose(state.position[0], expected_east, abs_tol=abs_tol)
+            assert isclose(state.position[1], expected_north, abs_tol=abs_tol)
+            assert isclose(state.orientation, expected_orientation, abs_tol=abs_tol)
+
+        assert sorted(seen_trajectory_state_timestamps) == list(range(1, 21))
+
+        # Check occupancies of trajectory prediction
+        seen_occupancy_timestamps = []
+        for occupancy in obs_prediction.occupancy_set:
+            seen_occupancy_timestamps.append(occupancy.time_step)
+            assert isinstance(occupancy.shape, Rectangle)
+            assert occupancy.shape.center[0] == expected_east
+            assert occupancy.shape.center[1] == expected_north
+            assert occupancy.shape.orientation == expected_orientation
+        assert sorted(seen_occupancy_timestamps) == list(range(1, 21))
+
+        expected_lanelet_id: int = 47240
+        expected_initial_lanelet_ids = set([expected_lanelet_id])
+        # Check lanelet references in obstacle
+        assert obstacle.initial_shape_lanelet_ids == expected_initial_lanelet_ids
+        assert obstacle.initial_center_lanelet_ids == expected_initial_lanelet_ids
+
+        # Check lanelet references in obstacle prediction
+        # They also added the initial state's lanelet assignment, which is a bag, but not a tragic one,
+        # so we tolerate it here.
+        # See also https://github.com/CommonRoad/commonroad-io/issues/13#issuecomment-2607990143
+        prediction_lanelet_assignment = {i: expected_initial_lanelet_ids for i in range(1, 21)}
+        prediction_lanelet_assignment_their_bug = {i: expected_initial_lanelet_ids for i in range(0, 21)}
+        assert (
+            obs_prediction.shape_lanelet_assignment == prediction_lanelet_assignment
+            or obs_prediction.shape_lanelet_assignment == prediction_lanelet_assignment_their_bug
+        )
+        assert (
+            obs_prediction.center_lanelet_assignment == prediction_lanelet_assignment
+            or obs_prediction.center_lanelet_assignment == prediction_lanelet_assignment_their_bug
+        )
+
+        # Other direction: check obstacle references in lanelets
+        expected_object_ids_on_lanelet = set([200, 201, 202, 203])
+        for time_step, ids in obs_prediction.shape_lanelet_assignment.items():
+            for lanelet_id in ids:
+                lanelet_dict = scenario.lanelet_network.find_lanelet_by_id(lanelet_id).dynamic_obstacles_on_lanelet
+                assert lanelet_dict[time_step] == expected_object_ids_on_lanelet
+
+    assert sorted(seen_obstacle_ids) == [200, 201, 202, 203]
+
     # Visual Insights
-    # utils_vis.visualize_scenario_at_time_steps(
-    #     scenario,
-    #     plot_limit=config_simplified_straight.debug.plot_limits,
-    #     time_steps=[0, 20],
-    #     print_obstacle_ids=True,
-    # )
-    # pass
+    utils_vis.visualize_scenario_at_time_steps(
+        scenario,
+        # plot_limit=example_config_garching.debug.plot_limits,
+        plot_limit=[-40, 70, -30, 30],
+        time_steps=[0, 20],
+        print_obstacle_ids=True,
+    )
+    pass
 
 
 if __name__ == "__main__":

--- a/research/delta_crit/scenario/simplify_scenario_test.py
+++ b/research/delta_crit/scenario/simplify_scenario_test.py
@@ -1,119 +1,46 @@
 import sys
-from math import isclose
 
-import commonroad_crime.utility.visualization as utils_vis  # type: ignore
+# import commonroad_crime.utility.visualization as utils_vis  # type: ignore
 import pytest
-from commonroad.geometry.shape import Rectangle  # type: ignore
-from commonroad.prediction.prediction import Occupancy, TrajectoryPrediction  # type: ignore
-from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
 from commonroad.scenario.scenario import Scenario  # type: ignore
-from commonroad.scenario.state import ExtendedPMState, InitialState  # type: ignore
 from commonroad_crime.data_structure.configuration import CriMeConfiguration  # type: ignore
 
+from research.delta_crit.scenario.assertion_utils import (
+    assert_constant_obstacle,
+    assert_obstacles_present,
+)
 from research.delta_crit.scenario.simplify_scenario import strip_down_to_test_scenario
 
 
-def test_simplify_scenario_all_properties_match(example_config_garching: CriMeConfiguration) -> None:
+def test_strip_down_scenario_all_properties_match(example_config_garching: CriMeConfiguration) -> None:
     # Function under test
     ego_id: int = 200
     scenario: Scenario = strip_down_to_test_scenario(scenario=example_config_garching.scenario, ego_id=ego_id)
 
     # Assertions
     ego_id = 200
-    abs_tol: float = 1e-11
-    for timestep in range(0, 22):
-        for obs_id in [200, 201, 202, 203]:
-            if timestep == 21:
-                assert scenario.obstacle_by_id(obs_id).state_at_time(timestep) is None
-                continue
-
-            expected_east: float = 0 if obs_id == ego_id else 10
-            expected_north: float = 0
-            expected_orientation: float = 0
-
-            obstacle: DynamicObstacle = scenario.obstacle_by_id(obs_id)
-
-            obstacle_state = obstacle.state_at_time(timestep)
-            assert isinstance(obstacle_state, InitialState if timestep == 0 else ExtendedPMState)
-
-            assert isclose(obstacle_state.position[0], expected_east, abs_tol=abs_tol)
-            assert isclose(obstacle_state.position[1], expected_north, abs_tol=abs_tol)
-            assert isclose(obstacle_state.orientation, expected_orientation, abs_tol=abs_tol)
-
-            obstacle_occupancy: Occupancy = obstacle.occupancy_at_time(timestep)
-            assert isinstance(obstacle_occupancy.shape, Rectangle)
-            assert obstacle_occupancy.shape.center[0] == expected_east
-            assert obstacle_occupancy.shape.center[1] == expected_north
-            assert obstacle_occupancy.shape.orientation == expected_orientation
-
-    # Assertions differently formulated
-    # TODO THIS IS INSANITY
-    # WRITE ASSERTION UTILITIES TO SIMPLIFY IT
-    seen_obstacle_ids = []
+    assert_obstacles_present(scenario=scenario, expected_obstacle_ids=[200, 201, 202, 203])
     for obstacle in scenario.dynamic_obstacles:
-        seen_obstacle_ids.append(obstacle.obstacle_id)
-
-        expected_east = 0 if obstacle.obstacle_id == ego_id else 10
-        expected_north = 0
-        expected_orientation = 0
-
-        # Check initial state
-        assert isclose(obstacle.initial_state.position[0], expected_east, abs_tol=abs_tol)
-        assert isclose(obstacle.initial_state.position[1], expected_north, abs_tol=abs_tol)
-        assert isclose(obstacle.initial_state.orientation, expected_orientation, abs_tol=abs_tol)
-
-        obs_prediction: TrajectoryPrediction = obstacle.prediction
-
-        # Check states of trajectory prediction
-        seen_trajectory_state_timestamps = []
-        for state in obs_prediction.trajectory.state_list:
-            seen_trajectory_state_timestamps.append(state.time_step)
-            assert isinstance(state, ExtendedPMState)
-            assert isclose(state.position[0], expected_east, abs_tol=abs_tol)
-            assert isclose(state.position[1], expected_north, abs_tol=abs_tol)
-            assert isclose(state.orientation, expected_orientation, abs_tol=abs_tol)
-
-        assert sorted(seen_trajectory_state_timestamps) == list(range(1, 21))
-
-        # Check occupancies of trajectory prediction
-        seen_occupancy_timestamps = []
-        for occupancy in obs_prediction.occupancy_set:
-            seen_occupancy_timestamps.append(occupancy.time_step)
-            assert isinstance(occupancy.shape, Rectangle)
-            assert occupancy.shape.center[0] == expected_east
-            assert occupancy.shape.center[1] == expected_north
-            assert occupancy.shape.orientation == expected_orientation
-        assert sorted(seen_occupancy_timestamps) == list(range(1, 21))
-
-        expected_lanelet_id: int = 47240
-        expected_initial_lanelet_ids = set([expected_lanelet_id])
-        # Check lanelet references in obstacle
-        assert obstacle.initial_shape_lanelet_ids == expected_initial_lanelet_ids
-        assert obstacle.initial_center_lanelet_ids == expected_initial_lanelet_ids
-
-        # Check lanelet references in obstacle prediction
-        expected_prediction_lanelet_assignment = {i: expected_initial_lanelet_ids for i in range(1, 21)}
-        assert obs_prediction.shape_lanelet_assignment == expected_prediction_lanelet_assignment
-        assert obs_prediction.center_lanelet_assignment == expected_prediction_lanelet_assignment
-
-        # Other direction: check obstacle references in lanelets
-        expected_object_ids_on_lanelet = set([200, 201, 202, 203])
-        for time_step, ids in obs_prediction.shape_lanelet_assignment.items():
-            for lanelet_id in ids:
-                lanelet_dict = scenario.lanelet_network.find_lanelet_by_id(lanelet_id).dynamic_obstacles_on_lanelet
-                assert lanelet_dict[time_step] == expected_object_ids_on_lanelet
-
-    assert sorted(seen_obstacle_ids) == [200, 201, 202, 203]
+        assert_constant_obstacle(
+            obstacle=obstacle,
+            expected_east=0 if obstacle.obstacle_id == ego_id else 10,
+            expected_north=0,
+            expected_orientation=0,
+            expected_initial_state_stamp=0,
+            expected_final_time_stamp=20,
+            expected_lanelet_ids=set([47240]),
+            lanelet_network=scenario.lanelet_network,
+        )
 
     # Visual Insights
-    utils_vis.visualize_scenario_at_time_steps(
-        scenario,
-        # plot_limit=example_config_garching.debug.plot_limits,
-        plot_limit=[-40, 70, -30, 30],
-        time_steps=[0, 20],
-        print_obstacle_ids=True,
-    )
-    pass
+    # utils_vis.visualize_scenario_at_time_steps(
+    #     scenario,
+    #     # plot_limit=example_config_garching.debug.plot_limits,
+    #     plot_limit=[-40, 70, -30, 30],
+    #     time_steps=[0, 20],
+    #     print_obstacle_ids=True,
+    # )
+    # pass
 
 
 if __name__ == "__main__":

--- a/research/delta_crit/scenario/simplify_scenario_test.py
+++ b/research/delta_crit/scenario/simplify_scenario_test.py
@@ -10,13 +10,13 @@ from commonroad.scenario.scenario import Scenario  # type: ignore
 from commonroad.scenario.state import ExtendedPMState, InitialState  # type: ignore
 from commonroad_crime.data_structure.configuration import CriMeConfiguration  # type: ignore
 
-from research.delta_crit.scenario.simplify_scenario import simplify_scenario
+from research.delta_crit.scenario.simplify_scenario import strip_down_to_test_scenario
 
 
 def test_simplify_scenario_all_properties_match(example_config_garching: CriMeConfiguration) -> None:
     # Function under test
     ego_id: int = 200
-    scenario: Scenario = simplify_scenario(scenario=example_config_garching.scenario, ego_id=ego_id)
+    scenario: Scenario = strip_down_to_test_scenario(scenario=example_config_garching.scenario, ego_id=ego_id)
 
     # Assertions
     ego_id = 200
@@ -92,19 +92,9 @@ def test_simplify_scenario_all_properties_match(example_config_garching: CriMeCo
         assert obstacle.initial_center_lanelet_ids == expected_initial_lanelet_ids
 
         # Check lanelet references in obstacle prediction
-        # They also added the initial state's lanelet assignment, which is a bag, but not a tragic one,
-        # so we tolerate it here.
-        # See also https://github.com/CommonRoad/commonroad-io/issues/13#issuecomment-2607990143
-        prediction_lanelet_assignment = {i: expected_initial_lanelet_ids for i in range(1, 21)}
-        prediction_lanelet_assignment_their_bug = {i: expected_initial_lanelet_ids for i in range(0, 21)}
-        assert (
-            obs_prediction.shape_lanelet_assignment == prediction_lanelet_assignment
-            or obs_prediction.shape_lanelet_assignment == prediction_lanelet_assignment_their_bug
-        )
-        assert (
-            obs_prediction.center_lanelet_assignment == prediction_lanelet_assignment
-            or obs_prediction.center_lanelet_assignment == prediction_lanelet_assignment_their_bug
-        )
+        expected_prediction_lanelet_assignment = {i: expected_initial_lanelet_ids for i in range(1, 21)}
+        assert obs_prediction.shape_lanelet_assignment == expected_prediction_lanelet_assignment
+        assert obs_prediction.center_lanelet_assignment == expected_prediction_lanelet_assignment
 
         # Other direction: check obstacle references in lanelets
         expected_object_ids_on_lanelet = set([200, 201, 202, 203])

--- a/research/delta_crit/scenario/utils.py
+++ b/research/delta_crit/scenario/utils.py
@@ -1,0 +1,68 @@
+# import numpy as np
+# from commonroad.geometry.shape import Rectangle  # type: ignore
+# from commonroad.prediction.prediction import TrajectoryPrediction  # type: ignore
+from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
+from commonroad.scenario.scenario import Scenario  # type: ignore
+
+# from commonroad.scenario.state import ExtendedPMState, InitialState  # type: ignore
+# from commonroad.scenario.trajectory import Trajectory  # type: ignore
+
+
+def refresh_dynamic_obstacles(scenario: Scenario) -> Scenario:
+    """Call this function after modifying object's positions or orientations.
+    It makes sure the scenario properties stay consistent."""
+
+    obstacle_ids: list[int] = [obs.obstacle_id for obs in scenario.dynamic_obstacles]
+
+    for obstacle_id in obstacle_ids:
+        previous_obstacle: DynamicObstacle = scenario.obstacle_by_id(obstacle_id)
+        fresh_copy_of_obstacle: DynamicObstacle = refresh_dynamic_obstacle(previous_obstacle)
+        scenario.remove_obstacle(previous_obstacle)
+        scenario.add_objects(fresh_copy_of_obstacle)
+
+    return scenario
+
+
+def refresh_dynamic_obstacle(obstacle: DynamicObstacle) -> DynamicObstacle:
+    """Maybe I just need to call obstacle.update_prediction()???"""
+
+    # TODO GO ON HERE!
+    obstacle.update_prediction()
+    obstacle.update_initial_state()
+    return obstacle
+
+    # initial_time_step: int = obstacle.initial_state.time_step
+
+    # ###
+    # dynamic_obstacle_initial_state: InitialState = InitialState(
+    #     time_step=initial_time_step,
+    #     position=np.array([position_x, position_y]),
+    #     velocity=velocity,
+    #     orientation=orientation,
+    # )
+
+    # after_initial_state_list: list[ExtendedPMState] = []
+    # for timestep in range(initial_time_step + 1, final_time_step + 1):
+    #     state = ExtendedPMState(
+    #         position=np.array([position_x, position_y]),
+    #         velocity=velocity,
+    #         orientation=orientation,
+    #         time_step=timestep,
+    #     )
+    #     after_initial_state_list.append(state)
+
+    # dynamic_obstacle_shape = Rectangle(width=width, length=length)
+
+    # dynamic_obstacle_trajectory = Trajectory(initial_time_step + 1, after_initial_state_list)
+    # dynamic_obstacle_prediction = TrajectoryPrediction(dynamic_obstacle_trajectory, dynamic_obstacle_shape)
+
+    # ###
+    # obstacle = DynamicObstacle(
+    #     obstacle_id=obstacle.obstacle_id,
+    #     obstacle_type=obstacle.obstacle_type,
+    #     obstacle_shape=obstacle.obstacle_shape,
+    #     initial_state=dynamic_obstacle_initial_state,
+    #     prediction=dynamic_obstacle_prediction,
+    #     initial_center_lanelet_ids=obstacle.initial_center_lanelet_ids,
+    # )
+    # return obstacle

--- a/research/delta_crit/scenario/utils.py
+++ b/research/delta_crit/scenario/utils.py
@@ -1,4 +1,5 @@
 # import numpy as np
+from copy import deepcopy
 from typing import Optional
 
 from commonroad.common.reader.file_reader_xml import DynamicObstacleFactory  #  type: ignore
@@ -14,48 +15,45 @@ from commonroad.scenario.state import InitialState, SignalState, TraceState  # t
 
 
 def refresh_dynamic_obstacles(scenario: Scenario) -> Scenario:
-    """Call this function after modifying object's positions or orientations.
+    """Call this function after modifying objects' positions or orientations.
     It makes sure the scenario properties stay consistent."""
 
     obstacle_ids: list[int] = [obs.obstacle_id for obs in scenario.dynamic_obstacles]
 
+    clear_dynamic_obstacles_from_lanelets(lanelet_network=scenario.lanelet_network)
+
     for obstacle_id in obstacle_ids:
-        previous_obstacle: DynamicObstacle = scenario.obstacle_by_id(obstacle_id)
-        scenario.lanelet_network
-        fresh_copy_of_obstacle: DynamicObstacle = refresh_dynamic_obstacle(
-            obstacle=previous_obstacle, lanelet_network=scenario.lanelet_network
-        )
-        scenario.remove_obstacle(previous_obstacle)
-        scenario.add_objects(fresh_copy_of_obstacle)
+        old_obstacle: DynamicObstacle = scenario.obstacle_by_id(obstacle_id)
+        new_obstacle = deepcopy(old_obstacle)
+        scenario.remove_obstacle(old_obstacle)
+        refresh_dynamic_obstacle(obstacle=old_obstacle, lanelet_network=scenario.lanelet_network)
+        scenario.add_objects(new_obstacle)
 
     return scenario
+
+
+def clear_dynamic_obstacles_from_lanelets(lanelet_network: LaneletNetwork) -> LaneletNetwork:
+    for lanelet in lanelet_network.lanelets:
+        lanelet.dynamic_obstacles_on_lanelet = {}
+    return lanelet_network
 
 
 def refresh_dynamic_obstacle(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
     """See https://github.com/CommonRoad/commonroad-io/issues/12"""
 
-    # TODO update the following
-    # TODO update initial state like this https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/scenario/obstacle.py#L675
-    # TODO fill arguments
     if not isinstance(obstacle.prediction, TrajectoryPrediction):
         raise ValueError("Can only refresh TrajectoryPrediction")
 
-    prediction: TrajectoryPrediction = obstacle.prediction
-    prediction._invalidate_occupancy_set()
-    prediction.occupancy_set  # recompute it
+    recompute_lanelet_assignments(obstacle=obstacle, lanelet_network=lanelet_network)
+    recompute_occupancy_set(obstacle.prediction)
 
-    # reset_initial_state(obstacle=obstacle, state=TODO)
-    obstacle.initial_shape_lanelet_ids
-    obstacle.initial_center_lanelet_ids
-
-    # needs to be computed manually and updated via the corresponding setter
-    # see also https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/common/reader/file_reader_xml.py#L1254
-    obstacle.prediction.shape_lanelet_assignment
-    obstacle.prediction.center_lanelet_assignment
-
-    # TODO fill arguments
-    obstacle.update_prediction()
     return obstacle
+
+
+def recompute_occupancy_set(prediction: TrajectoryPrediction) -> TrajectoryPrediction:
+    prediction._invalidate_occupancy_set()
+    _ = prediction.occupancy_set  # recompute it
+    return prediction
 
 
 def reset_initial_state(
@@ -71,32 +69,59 @@ def reset_initial_state(
     return obstacle
 
 
-def recompute_lanelet_assignment(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
-    """Input: obstacle.prediction.trajectory
+def recompute_lanelet_assignments(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
+    """
+    Based on modified
+    - obstacle.prediction.trajectory
+    - obstacle.initial_state,
+    recompute which lanelets their shapes and centers are on.
+
+    Adds the new obstacle information to the lanelets, but does not delete the old one.
 
     See also https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/common/reader/file_reader_xml.py#L1254"""
 
-    if not isinstance(obstacle.prediction, TrajectoryPrediction):
-        raise ValueError("Can only recompute lanelet assignment for TrajectoryPrediction")
-    prediction: TrajectoryPrediction = obstacle.prediction
+    recompute_initial_lanelet_assignment(obstacle=obstacle, lanelet_network=lanelet_network)
+    recompute_prediction_lanelet_assignment(obstacle=obstacle, lanelet_network=lanelet_network)
+    return obstacle
+
+
+def recompute_initial_lanelet_assignment(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
     initial_state: InitialState = obstacle.initial_state
 
+    # Recompute initial lanelet ids
     # TODO: this might be buggy, take care.
     rotated_shape = obstacle.obstacle_shape.rotate_translate_local(initial_state.position, initial_state.orientation)
     obstacle.initial_shape_lanelet_ids = set(lanelet_network.find_lanelet_by_shape(rotated_shape))
     obstacle.initial_center_lanelet_ids = set(lanelet_network.find_lanelet_by_position([initial_state.position])[0])
 
-    # TODO: clear all existing dynamic obstacles from the lanelets before adding the refreshed ones
+    # Add initial state to these newly-computed lanelet ids
+    add_initial_state_to_its_lanelets(obstacle=obstacle, lanelet_network=lanelet_network)
+    return obstacle
+
+
+def add_initial_state_to_its_lanelets(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> LaneletNetwork:
+    """Adds, but does not delete any existing states from the lanelets."""
     for l_id in obstacle.initial_shape_lanelet_ids:
         lanelet_network.find_lanelet_by_id(l_id).add_dynamic_obstacle_to_lanelet(
-            obstacle_id=obstacle.obstacle_id, time_step=initial_state.time_step
+            obstacle_id=obstacle.obstacle_id, time_step=obstacle.initial_state.time_step
         )
+    return lanelet_network
 
+
+def recompute_prediction_lanelet_assignment(
+    obstacle: DynamicObstacle, lanelet_network: LaneletNetwork
+) -> DynamicObstacle:
+    # Input checks and syntactic sugar
+    if not isinstance(obstacle.prediction, TrajectoryPrediction):
+        raise ValueError("Can only recompute lanelet assignment for TrajectoryPrediction")
+    prediction: TrajectoryPrediction = obstacle.prediction
+    initial_state: InitialState = obstacle.initial_state
+
+    # Actual recomputation
     prediction.shape_lanelet_assignment = DynamicObstacleFactory.find_obstacle_shape_lanelets(
         initial_state, prediction.trajectory.state_list, lanelet_network, obstacle.obstacle_id, obstacle.obstacle_shape
     )
     prediction.center_lanelet_assignment = DynamicObstacleFactory.find_obstacle_center_lanelets(
         initial_state, prediction.trajectory.state_list, lanelet_network
     )
-
     return obstacle

--- a/research/delta_crit/scenario/utils.py
+++ b/research/delta_crit/scenario/utils.py
@@ -1,10 +1,15 @@
 # import numpy as np
+from typing import Optional
+
+from commonroad.common.reader.file_reader_xml import DynamicObstacleFactory  #  type: ignore
+
 # from commonroad.geometry.shape import Rectangle  # type: ignore
-# from commonroad.prediction.prediction import TrajectoryPrediction  # type: ignore
+from commonroad.prediction.prediction import TrajectoryPrediction  # type: ignore
+from commonroad.scenario.lanelet import LaneletNetwork  # type: ignore
 from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
 from commonroad.scenario.scenario import Scenario  # type: ignore
+from commonroad.scenario.state import InitialState, SignalState, TraceState  # type: ignore
 
-# from commonroad.scenario.state import ExtendedPMState, InitialState  # type: ignore
 # from commonroad.scenario.trajectory import Trajectory  # type: ignore
 
 
@@ -16,53 +21,82 @@ def refresh_dynamic_obstacles(scenario: Scenario) -> Scenario:
 
     for obstacle_id in obstacle_ids:
         previous_obstacle: DynamicObstacle = scenario.obstacle_by_id(obstacle_id)
-        fresh_copy_of_obstacle: DynamicObstacle = refresh_dynamic_obstacle(previous_obstacle)
+        scenario.lanelet_network
+        fresh_copy_of_obstacle: DynamicObstacle = refresh_dynamic_obstacle(
+            obstacle=previous_obstacle, lanelet_network=scenario.lanelet_network
+        )
         scenario.remove_obstacle(previous_obstacle)
         scenario.add_objects(fresh_copy_of_obstacle)
 
     return scenario
 
 
-def refresh_dynamic_obstacle(obstacle: DynamicObstacle) -> DynamicObstacle:
-    """Maybe I just need to call obstacle.update_prediction()???"""
+def refresh_dynamic_obstacle(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
+    """See https://github.com/CommonRoad/commonroad-io/issues/12"""
 
-    # TODO GO ON HERE!
+    # TODO update the following
+    # TODO update initial state like this https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/scenario/obstacle.py#L675
+    # TODO fill arguments
+    if not isinstance(obstacle.prediction, TrajectoryPrediction):
+        raise ValueError("Can only refresh TrajectoryPrediction")
+
+    prediction: TrajectoryPrediction = obstacle.prediction
+    prediction._invalidate_occupancy_set()
+    prediction.occupancy_set  # recompute it
+
+    # reset_initial_state(obstacle=obstacle, state=TODO)
+    obstacle.initial_shape_lanelet_ids
+    obstacle.initial_center_lanelet_ids
+
+    # needs to be computed manually and updated via the corresponding setter
+    # see also https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/common/reader/file_reader_xml.py#L1254
+    obstacle.prediction.shape_lanelet_assignment
+    obstacle.prediction.center_lanelet_assignment
+
+    # TODO fill arguments
     obstacle.update_prediction()
-    obstacle.update_initial_state()
     return obstacle
 
-    # initial_time_step: int = obstacle.initial_state.time_step
 
-    # ###
-    # dynamic_obstacle_initial_state: InitialState = InitialState(
-    #     time_step=initial_time_step,
-    #     position=np.array([position_x, position_y]),
-    #     velocity=velocity,
-    #     orientation=orientation,
-    # )
+def reset_initial_state(
+    obstacle: DynamicObstacle,
+    state: TraceState,
+    signal_state: Optional[SignalState] = None,
+) -> DynamicObstacle:
+    """Modification of official `update_initial_state`.
+    Here, without doing a time step. No history gets appended and no prediction gets invalidated.
+    Also without recomputing lanelet assignments, as this is done elsewhere."""
+    obstacle.initial_state = state
+    obstacle.initial_signal_state = signal_state
+    return obstacle
 
-    # after_initial_state_list: list[ExtendedPMState] = []
-    # for timestep in range(initial_time_step + 1, final_time_step + 1):
-    #     state = ExtendedPMState(
-    #         position=np.array([position_x, position_y]),
-    #         velocity=velocity,
-    #         orientation=orientation,
-    #         time_step=timestep,
-    #     )
-    #     after_initial_state_list.append(state)
 
-    # dynamic_obstacle_shape = Rectangle(width=width, length=length)
+def recompute_lanelet_assignment(obstacle: DynamicObstacle, lanelet_network: LaneletNetwork) -> DynamicObstacle:
+    """Input: obstacle.prediction.trajectory
 
-    # dynamic_obstacle_trajectory = Trajectory(initial_time_step + 1, after_initial_state_list)
-    # dynamic_obstacle_prediction = TrajectoryPrediction(dynamic_obstacle_trajectory, dynamic_obstacle_shape)
+    See also https://github.com/CommonRoad/commonroad-io/blob/95511a554a9ed97fb9e3a88b6c1d1101839e2d49/commonroad/common/reader/file_reader_xml.py#L1254"""
 
-    # ###
-    # obstacle = DynamicObstacle(
-    #     obstacle_id=obstacle.obstacle_id,
-    #     obstacle_type=obstacle.obstacle_type,
-    #     obstacle_shape=obstacle.obstacle_shape,
-    #     initial_state=dynamic_obstacle_initial_state,
-    #     prediction=dynamic_obstacle_prediction,
-    #     initial_center_lanelet_ids=obstacle.initial_center_lanelet_ids,
-    # )
-    # return obstacle
+    if not isinstance(obstacle.prediction, TrajectoryPrediction):
+        raise ValueError("Can only recompute lanelet assignment for TrajectoryPrediction")
+    prediction: TrajectoryPrediction = obstacle.prediction
+    initial_state: InitialState = obstacle.initial_state
+
+    # TODO: this might be buggy, take care.
+    rotated_shape = obstacle.obstacle_shape.rotate_translate_local(initial_state.position, initial_state.orientation)
+    obstacle.initial_shape_lanelet_ids = set(lanelet_network.find_lanelet_by_shape(rotated_shape))
+    obstacle.initial_center_lanelet_ids = set(lanelet_network.find_lanelet_by_position([initial_state.position])[0])
+
+    # TODO: clear all existing dynamic obstacles from the lanelets before adding the refreshed ones
+    for l_id in obstacle.initial_shape_lanelet_ids:
+        lanelet_network.find_lanelet_by_id(l_id).add_dynamic_obstacle_to_lanelet(
+            obstacle_id=obstacle.obstacle_id, time_step=initial_state.time_step
+        )
+
+    prediction.shape_lanelet_assignment = DynamicObstacleFactory.find_obstacle_shape_lanelets(
+        initial_state, prediction.trajectory.state_list, lanelet_network, obstacle.obstacle_id, obstacle.obstacle_shape
+    )
+    prediction.center_lanelet_assignment = DynamicObstacleFactory.find_obstacle_center_lanelets(
+        initial_state, prediction.trajectory.state_list, lanelet_network
+    )
+
+    return obstacle

--- a/research/delta_crit/scenario/utils.py
+++ b/research/delta_crit/scenario/utils.py
@@ -2,15 +2,11 @@
 from copy import deepcopy
 
 from commonroad.common.reader.file_reader_xml import DynamicObstacleFactory  #  type: ignore
-
-# from commonroad.geometry.shape import Rectangle  # type: ignore
 from commonroad.prediction.prediction import TrajectoryPrediction  # type: ignore
 from commonroad.scenario.lanelet import LaneletNetwork  # type: ignore
 from commonroad.scenario.obstacle import DynamicObstacle  # type: ignore
 from commonroad.scenario.scenario import Scenario  # type: ignore
 from commonroad.scenario.state import InitialState  # type: ignore
-
-# from commonroad.scenario.trajectory import Trajectory  # type: ignore
 
 
 def refresh_dynamic_obstacles(scenario: Scenario) -> Scenario:
@@ -107,18 +103,9 @@ def recompute_prediction_lanelet_assignment(
 
     # Note that the following two functions also add the initial_state's lanelets to the
     # prediction's {shape|center}_lanelet_assignment.
-    # If the intial state is one step earlier than prediction.trajectory.state_list[0],
-    # its lanelets will be stored under a separate dict key.
-    # If the intial state is at the same time step as prediction.trajectory.state_list[0],
-    # then the following functions overwrite the initial_state's lanelets by the ones of
-    # prediction.trajectory.state_list[0].
-    # In general, the initial_state should be 1 time step before the prediction's first state:
-    # https://github.com/CommonRoad/commonroad-io/issues/13
-
-    # This seems a bit messy to me, but
-    # apparently, this is how it works in commonroad. Most likely, it is safe to assume
-    # that the initial_state is the prediction.trajectory.state_list[0] anyway.
-    # In the scenario xml file, initial_state can be a time step earlier.
+    # This should be no problem because CommonRoad intends the initial state to be
+    # one time step earlier than the prediction's first state.
+    # See also https://github.com/CommonRoad/commonroad-io/issues/13.
 
     # This also adds the shape lanelets to the lanelet network!
     prediction.shape_lanelet_assignment = DynamicObstacleFactory.find_obstacle_shape_lanelets(
@@ -134,5 +121,4 @@ def recompute_prediction_lanelet_assignment(
     prediction.center_lanelet_assignment = DynamicObstacleFactory.find_obstacle_center_lanelets(
         obstacle.initial_state, prediction.trajectory.state_list, lanelet_network
     )
-
     return obstacle


### PR DESCRIPTION
TODO 
- [x] recompute the occupancy of the initial state (`obstacle.occupancy_at_time(0).shape`). Apparently, this needs to be done separately from the prediction's occupancy invalidation.
- [x] add the assertion about initial occupancy to the assertion utils (or more specifically, initial occupancy shape)
- [x] tidy up assertions in other functions